### PR TITLE
fixed parsing query string only if there is query string param

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -43,9 +43,11 @@ searchBtn.on("click", function(event){
 //get query string param from url
 //console.log(window.location.search);
 var queryStringParam = window.location.search;
-var queryPair = queryStringParam.split("?");
-//console.log(queryPair);
-var queryKeyValue = queryPair[1].split("=");
-//console.log(queryKeyValue);
-console.log("queryKeyValue[0]: " + queryKeyValue[0]);
-console.log("queryKeyValue[1]: " + queryKeyValue[1]);
+if (queryStringParam) {
+    var queryPair = queryStringParam.split("?");
+    //console.log(queryPair);
+    var queryKeyValue = queryPair[1].split("=");
+    //console.log(queryKeyValue);
+    console.log("queryKeyValue[0]: " + queryKeyValue[0]);
+    console.log("queryKeyValue[1]: " + queryKeyValue[1]);
+}


### PR DESCRIPTION
Hi there.

This fixes where if you load the medals.html on its own and if it has not query string param like medals.html?medal=bronze in the url, it won't throw an error about that missing query string param.

Thank you,
Claudia