### PR TITLE
extracted NYT data for headline and link and saved in local storage a…

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -1,14 +1,17 @@
 //DEPENDENCIES =================================================================
 var searchBtn = $("#search-usa-medalist");
 
+var articlesArray = [];
+
 
 //DATA =========================================================================
 
 //FUNCTIONS ====================================================================
-function searchNews(searchTerm) {
+async function searchNews(searchTerm) {
 
     constructedNEWSURL = "https://api.nytimes.com/svc/search/v2/articlesearch.json?q=" + searchTerm + "&api-key=GGFWJmCqMq0NCTFkqwJ3PAgGRrCDZmlJ"
-    fetch(constructedNEWSURL, {
+
+    var data = await fetch(constructedNEWSURL, {
         method: "GET", //GET is the default.
         credentials: "same-origin", // include, *same-origin, omit
         redirect: "follow", // manual, *follow, error
@@ -16,15 +19,29 @@ function searchNews(searchTerm) {
         .then(function (response) {
             return response.json();
         })
-        .then(function (data) {
-            console.log("===== SEARCH RESULTS: =====");
-            console.log(data);
-        })
-        .catch(function (err) {
-            alert("Please make sure you entered a search term.");
+ 
+    extractAndStoreNYTData(data);
 
-        });
+}
 
+function extractAndStoreNYTData (NYTData) {
+
+    //extract headline and link to story
+    for (var i=0; i < NYTData.response.docs.length; i++) {
+        var snippet = NYTData.response.docs[i].snippet;
+        var web_url = NYTData.response.docs[i].web_url;
+        articlesArray.push({headline: snippet, storyLink: web_url});
+    }
+
+    //save in localstorage
+    localStorage.setItem("articlesArray", JSON.stringify(articlesArray));
+
+}
+
+function getArticlesArrayFromLocalStorage() {
+
+    var lastArticles = JSON.parse(localStorage.getItem("articlesArray"));
+    return lastArticles;
 }
 
 //USER INTERACTIONS ============================================================
@@ -41,13 +58,10 @@ searchBtn.on("click", function(event){
 });
 
 //get query string param from url
-//console.log(window.location.search);
 var queryStringParam = window.location.search;
 if (queryStringParam) {
     var queryPair = queryStringParam.split("?");
-    //console.log(queryPair);
     var queryKeyValue = queryPair[1].split("=");
-    //console.log(queryKeyValue);
-    console.log("queryKeyValue[0]: " + queryKeyValue[0]);
-    console.log("queryKeyValue[1]: " + queryKeyValue[1]);
+    //console.log("queryKeyValue[0]: " + queryKeyValue[0]);
+    //console.log("queryKeyValue[1]: " + queryKeyValue[1]);
 }


### PR DESCRIPTION
…lso added getter function to retrieve from local storage and kept asynchAwait

Hi there.

This p.r. has a lot of functionality added in js.
1. NYT articles returned, each one's headline and link to news page is extracted from the API call. (there are usually 10 responses NYT provides fyi)
2. Those 2 parts are then saved in local storage in an array of objects.
3. Once you have fetched this branch, launch the index.html to your default browser.
4. Next open your dev toolbar (same as console) and go to the Application > Storage > Local Storage.
5. Then enter a search term and click search button.
6. You should see an update in Local Storage.
7. Click on the new key named articlesArray that should now be saved. (this is a confirmation)
8. Twirl open articlesArray's elements 0-n and confirm you see headline and storyLink objects with their appropriate values.
9. Reload the page to confirm you still see articlesArray in local storage.
10. Enter a new search term, and repeat steps 6-9 and confirm again.

Please note I added a getter function to retrieve from local storage but there is nothing using this getter so this is not for confirming at this time and will be confirmed separately.

Thank you,
Claudia